### PR TITLE
fix bugs, typos, docs, bump ver, add night mode

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -90,6 +90,7 @@ though.
 ```
 conda create -n mypackage python=3.8
 conda activate mypackage
+conda install -c conda-forge tox-conda
 ```
 
 You could choose your favorite python version here. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,13 +8,22 @@ nav:
   - Release checklist: pypi_release_checklist.md
   - FAQ: faq.md
   - History: history.md
-  
+
 theme:
   name: material
   language: en
   #logo: assets/logo.png
   palette:
-    primary: light blue
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   features:
     - navigation.indexes
     - navigation.tabs

--- a/{{cookiecutter.project_slug}}/.github/workflows/dev.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/dev.yml
@@ -2,13 +2,13 @@
 
 name: dev workflow
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master,main,release ]
+    branches: [master, main, release]
   pull_request:
-    branches: [ master,main,release ]
+    branches: [master, main, release]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,7 +20,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        python-versions: [3.6, 3.7, 3.8, 3.9]
+        python-versions: [3.7, 3.8, 3.9]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -38,8 +38,7 @@ jobs:
           pip install poetry tox tox-gh-actions
 
       - name: test with tox
-        run:
-          tox
+        run: tox
 
       - name: list files
         run: ls -l .
@@ -60,8 +59,7 @@ jobs:
           pip install poetry tox tox-gh-actions
 
       - name: test with tox
-        run:
-          tox
+        run: tox
 
       - name: list files
         run: ls -l .

--- a/{{cookiecutter.project_slug}}/.isort.cfg
+++ b/{{cookiecutter.project_slug}}/.isort.cfg
@@ -1,9 +1,4 @@
 [settings]
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-ensure_newline_before_comments = True
-line_length = 88
+profile=black
 # you can skip files as below
 #skip_glob = docs/conf.py

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -126,4 +126,4 @@ $ git push
 $ git push --tags
 ```
 
-Travis will then deploy to PyPI if tests pass.
+Github Actions will then deploy to PyPI if tests pass.

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -12,8 +12,8 @@
     <img src="https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/actions/workflows/main.yml/badge.svg?branch=release" alt="CI Status">
 </a>
 
-<a href="https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest">
-    <img src="https://readthedocs.org/projects/{{ cookiecutter.project_slug | replace("_", "-") }}/badge/?version=latest" alt="Documentation Status">
+<a href="https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.project_slug }}/">
+    <img src="https://img.shields.io/website/https/{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.project_slug }}/index.html.svg?label=docs&down_message=unavailable&up_message=available" alt="Documentation Status">
 </a>
 {% if cookiecutter.add_pyup_badge == 'y' %}
 <a href="https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/">
@@ -35,7 +35,7 @@
 
 {% if is_open_source %}
 * Free software: {{ cookiecutter.open_source_license }}
-* Documentation: <https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io>
+* Documentation: <https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.project_slug }}/>
 {% endif %}
 
 ## Features

--- a/{{cookiecutter.project_slug}}/mkdocs.yml
+++ b/{{cookiecutter.project_slug}}/mkdocs.yml
@@ -17,7 +17,16 @@ theme:
   language: en
   #logo: assets/logo.png
   palette:
-    primary: light blue
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   features:
     - navigation.indexes
     - navigation.tabs

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -24,7 +24,6 @@ classifiers=[
 {%- endif %}
     'Natural Language :: English',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
@@ -35,29 +34,31 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6.1,<4.0"
+python = ">=3.7.1,<4.0"
 {%- if cookiecutter.command_line_interface|lower == 'fire' %}
 fire = "0.4.0"
 {%- endif %}
 
-black  = { version = "20.8b1", optional = true}
-isort  = { version = "5.6.4", optional = true}
-flake8  = { version = "3.8.4", optional = true}
+black  = { version = "22.1.0", optional = true}
+isort  = { version = "5.10.1", optional = true}
+flake8  = { version = "4.0.1", optional = true}
 flake8-docstrings = { version = "^1.6.0", optional = true }
-pytest  = { version = "6.1.2", optional = true}
-pytest-cov  = { version = "2.10.1", optional = true}
-tox  = { version = "^3.20.1", optional = true}
-virtualenv  = { version = "^20.2.2", optional = true}
-pip  = { version = "^20.3.1", optional = true}
-mkdocs  = { version = "^1.1.2", optional = true}
-mkdocs-include-markdown-plugin  = { version = "^1.0.0", optional = true}
-mkdocs-material  = { version = "^6.1.7", optional = true}
-mkdocstrings  = { version = "^0.13.6", optional = true}
-mkdocs-material-extensions  = { version = "^1.0.1", optional = true}
-twine  = { version = "^3.3.0", optional = true}
-mkdocs-autorefs = {version = "0.1.1", optional = true}
-pre-commit = {version = "^2.12.0", optional = true}
+pytest  = { version = "^7.0.1", optional = true}
+pytest-cov  = { version = "^3.0.0", optional = true}
+tox  = { version = "^3.24.5", optional = true}
+virtualenv  = { version = "^20.13.1", optional = true}
+pip  = { version = "^22.0.3", optional = true}
+mkdocs  = { version = "^1.2.3", optional = true}
+mkdocs-include-markdown-plugin  = { version = "^3.2.3", optional = true}
+mkdocs-material  = { version = "^8.1.11", optional = true}
+mkdocstrings  = { version = "^0.18.0", optional = true}
+mkdocs-material-extensions  = { version = "^1.0.3", optional = true}
+twine  = { version = "^3.8.0", optional = true}
+mkdocs-autorefs = {version = "^0.3.1", optional = true}
+pre-commit = {version = "^2.17.0", optional = true}
 toml = {version = "^0.10.2", optional = true}
+livereload = {version = "^2.6.3", optional = true}
+pyreadline = {version = "^2.1", optional = true}
 
 [tool.poetry.extras]
 test = [
@@ -106,3 +107,5 @@ exclude = '''
   | dist
 )/
 '''
+[tool.isort]
+profile = "black"

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 isolated_build = true
-envlist = py36, py37, py38, py39, lint, format
+envlist = py37, py38, py39, lint, format
 
 [gh-actions]
 python =
     3.9: py39
     3.8: py38
     3.7: py37
-    3.6: py36
 
 [testenv:lint]
 whitelist_externals =


### PR DESCRIPTION
This PR fixes the below:
1- Docs badge to use gh-pages
2- Adds instructions to use tox-conda as installation suggests setting a conda enviroment.
3- Bumps dependencies versions to latest and drop support to python 3.6
4- Adds missing dependencies.
5- Fix some typos
6- Use profile=black for isort in both toml file and isort.cfg file (can be deleted but i didn't try)
7- Adds night mode to gh-pages
8- fixes some indentations

Thanks!